### PR TITLE
[#24] Add CMakePresets.json

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,6 +9,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  PRESET: linux_release
 
 jobs:
   ################################
@@ -18,7 +19,7 @@ jobs:
     # Name the Job
     name: Lint Code Base
     # Set the agent to run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # TODO: Switch back to ununtu-latest when bug in github CI will be fixed
 
     steps:
       - name: Checkout Code
@@ -41,7 +42,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CC: clang
       CXX: clang++
@@ -52,37 +53,39 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_STANDARD=20
+        run: cmake --preset ${{env.PRESET}}
 
       - name: Build
         # Build your program with the given configuration
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+        run: cmake --build ${{github.workspace}}/build/${{env.PRESET}} --parallel
 
       - name: Upload build directory to artefact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build_directory
-          path: ${{github.workspace}}/build/
+          path: |
+            ${{github.workspace}}/build/${{env.PRESET}}/algebra/tests/testVector
+            ${{github.workspace}}/build/${{env.PRESET}}/algebra/tests/testMatrix
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build
 
     steps:
       - name: Download build directory
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build_directory
           path: build
 
       - name: Update mode for test executable
-        run: chmod +x ./build/algebra/tests/testVector ./build/algebra/tests/testMatrix
+        run: chmod +x ./build/testVector ./build/testMatrix
 
       - name: Test algebra module
         working-directory: build
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure --test-dir algebra/tests
+        run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
       - name: Clean build directory artifact
         uses: geekyeggo/delete-artifact@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,14 @@ Include(FetchContent)
 FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v3.0.1 # or a later release
+    GIT_TAG        v3.5.0
 )
 
 FetchContent_MakeAvailable(Catch2)
 list(APPEND CMAKE_MODULE_PATH "${catch2_SOURCE_DIR}/extras")
+
+# Make CTest available for targets
+include(CTest)
 
 add_subdirectory(algebra)
 add_subdirectory(combinatorics)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,47 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 25,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "Base Linux",
+            "description": "Options common to all presets",
+            "hidden": true,
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/${presetName}"
+        },
+        {
+            "name": "linux_release",
+            "hidden": false,
+            "inherits": [
+                "Base Linux"
+            ],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "linux_relwithdebinfo",
+            "hidden": false,
+            "inherits": [
+                "Base Linux"
+            ],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        },
+        {
+            "name": "linux_debug",
+            "hidden": false,
+            "inherits": [
+                "Base Linux"
+            ],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        }
+    ]
+}

--- a/algebra/CMakeLists.txt
+++ b/algebra/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_library(lcnsAlgebra)
 
 target_sources(lcnsAlgebra
-               PUBLIC
-               "include/algebra/Internal.hpp"
-               "include/algebra/Vector.hpp"
-               "include/algebra/Algebra.hpp"
-               "include/algebra/Matrix.hpp"
+    PUBLIC
+        "include/algebra/Internal.hpp"
+        "include/algebra/Vector.hpp"
+        "include/algebra/Algebra.hpp"
+        "include/algebra/Matrix.hpp"
 )
 
 target_include_directories(lcnsAlgebra PUBLIC "include")

--- a/algebra/tests/CMakeLists.txt
+++ b/algebra/tests/CMakeLists.txt
@@ -1,29 +1,41 @@
 add_executable(testVector)
 
 target_sources(testVector
-               PRIVATE
-               "TestVector2.cpp"
-               "TestVector3.cpp"
-               "TestVector4.cpp"
+    PRIVATE
+        "TestVector2.cpp"
+        "TestVector3.cpp"
+        "TestVector4.cpp"
 )
 
 target_link_libraries(testVector PRIVATE lcns::algebra Catch2::Catch2WithMain)
 
+target_compile_features(testVector PUBLIC cxx_std_20)
+
+set_target_properties(testVector PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(testVector PROPERTIES CXX_EXTENSIONS OFF)
+
+add_test(NAME "Test vec2" COMMAND "$<TARGET_FILE:testVector>" "[algebra][vector][dim2]")
+add_test(NAME "Test vec3" COMMAND "$<TARGET_FILE:testVector>" "[algebra][vector][dim3]")
+add_test(NAME "Test vec4" COMMAND "$<TARGET_FILE:testVector>" "[algebra][vector][dim4]")
+
 add_executable(testMatrix)
 
 target_sources(testMatrix
-               PRIVATE
-               "Helper.hpp"
-               "TestMatrix2x2.cpp"
-               "TestMatrix3x3.cpp"
-               "TestMatrix4x4.cpp"
-               "TestMatrixMxN.cpp"
+    PRIVATE
+        "Helper.hpp"
+        "TestMatrix2x2.cpp"
+        "TestMatrix3x3.cpp"
+        "TestMatrix4x4.cpp"
+        "TestMatrixMxN.cpp"
 )
 
 target_link_libraries(testMatrix PRIVATE lcns::algebra Catch2::Catch2WithMain)
 
+target_compile_features(testMatrix PUBLIC cxx_std_20)
 
-include(CTest)
-include(Catch)
-catch_discover_tests(testVector)
-catch_discover_tests(testMatrix)
+set_target_properties(testMatrix PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(testMatrix PROPERTIES CXX_EXTENSIONS OFF)
+
+add_test(NAME "Test mat2" COMMAND "$<TARGET_FILE:testMatrix>" "[algebra][matrix][dim2]")
+add_test(NAME "Test mat3" COMMAND "$<TARGET_FILE:testMatrix>" "[algebra][matrix][dim3]")
+add_test(NAME "Test mat4" COMMAND "$<TARGET_FILE:testMatrix>" "[algebra][matrix][dim4]")


### PR DESCRIPTION
- Update version of Catch2 to v3.5.0
- Call tests using CTest instead of Catch2 specific command
- Enable c++20 for test targets - Temporarily use older version of ubuntu: This is due to a bug in github CI (std::chrono and consteval in Catch2)